### PR TITLE
Prevent Source from blocking a port forever

### DIFF
--- a/c_src/membrane_rtmp_plugin/source/rtmp_source.c
+++ b/c_src/membrane_rtmp_plugin/source/rtmp_source.c
@@ -3,7 +3,13 @@
 
 void handle_init_state(State *);
 
-UNIFEX_TERM native_create(UnifexEnv *env, char *url, char *timeout) {
+static int interrupt_cb(void *ctx) {
+  bool is_terminating = *(bool *)ctx;
+  // interrupt if the flag is set
+  return is_terminating;
+}
+
+UNIFEX_TERM create(UnifexEnv *env) {
   State *s = unifex_alloc_state(env);
   handle_init_state(s);
 
@@ -12,32 +18,40 @@ UNIFEX_TERM native_create(UnifexEnv *env, char *url, char *timeout) {
     return unifex_raise(env, "Could not find filter h264_mp4toannexb");
   }
 
-  UNIFEX_TERM ret;
+  s->input_ctx->interrupt_callback.callback = interrupt_cb;
+  s->input_ctx->interrupt_callback.opaque = &s->terminating;
+  return create_result_ok(env, s);
+}
 
+UNIFEX_TERM await_open(UnifexEnv *env, State *s, char *url, int timeout) {
   AVDictionary *d = NULL;
   av_dict_set(&d, "listen", "1", 0);
+  av_dict_set_int(&d, "timeout", timeout, 0);
 
-  // 0 indicates that timeout should be infinity
-  if (strcmp(timeout, "0") != 0) {
-    av_dict_set(&d, "timeout", timeout, 0);
-  }
+  UNIFEX_TERM ret;
 
-  if (avformat_open_input(&s->input_ctx, url, NULL, &d) < 0) {
-    ret = native_create_result_error(
-        env, "Couldn't open input. This might be caused by invalid address, "
-             "occupied port or connection timeout");
+  int av_err = avformat_open_input(&s->input_ctx, url, NULL, &d);
+  if (av_err == AVERROR(ETIMEDOUT)) {
+    ret = await_open_result_error_timeout(env);
+    goto err;
+  } else if (av_err == AVERROR_EXIT) {
+    // Error returned when interrupt_cb returns non-zero
+    ret = await_open_result_error_interrupted(env);
+    goto err;
+  } else if (av_err < 0) {
+    ret = await_open_result_error(env, av_err2str(av_err));
     goto err;
   }
 
   if (avformat_find_stream_info(s->input_ctx, NULL) < 0) {
-    ret = native_create_result_error(env, "Couldn't get stream info");
+    ret = await_open_result_error(env, "Couldn't get stream info");
     goto err;
   }
 
   s->number_of_streams = s->input_ctx->nb_streams;
 
   if (s->number_of_streams == 0) {
-    ret = native_create_result_error(
+    ret = await_open_result_error(
         env, "No streams found - at least one stream is required");
     goto err;
   }
@@ -52,17 +66,26 @@ UNIFEX_TERM native_create(UnifexEnv *env, char *url, char *timeout) {
 
     if (in_codecpar->codec_id != AV_CODEC_ID_H264 &&
         in_codecpar->codec_id != AV_CODEC_ID_AAC) {
-      ret = native_create_result_error(
+      ret = await_open_result_error(
           env, "Unsupported codec. Only H264 and AAC are supported");
       goto err;
+    }
+    if (in_codecpar->codec_id == AV_CODEC_ID_H264) {
+      s->h264_bsf_ctx->time_base_in = in_stream->time_base;
+      s->h264_bsf_ctx->par_in->codec_id = in_codecpar->codec_id;
     }
   }
 
   av_bsf_init(s->h264_bsf_ctx);
-  ret = native_create_result_ok(env, s);
+  ret = await_open_result_ok(env, s);
 err:
   unifex_release_state(env, s);
   return ret;
+}
+
+UNIFEX_TERM set_terminate(UnifexEnv *env, State *s) {
+  s->terminating = true;
+  return set_terminate_result_ok(env);
 }
 
 UNIFEX_TERM get_audio_params(UnifexEnv *env, State *s) {
@@ -140,7 +163,7 @@ UNIFEX_TERM read_frame(UnifexEnv *env, State *s) {
     }
   }
 
-  UNIFEX_TERM (*result_func)
+  UNIFEX_TERM(*result_func)
   (UnifexEnv *, int64_t, int64_t, UnifexPayload *) = NULL;
 
   switch (codec_type) {
@@ -172,13 +195,15 @@ end:
 
 void handle_init_state(State *s) {
   s->input_ctx = avformat_alloc_context();
-  s->ready = false;
+  s->terminating = false;
   const AVBitStreamFilter *h264_filter = av_bsf_get_by_name("h264_mp4toannexb");
   av_bsf_alloc(h264_filter, &s->h264_bsf_ctx);
 }
 
 void handle_destroy_state(UnifexEnv *env, State *s) {
   UNIFEX_UNUSED(env);
+
+  s->terminating = true;
 
   if (s->h264_bsf_ctx) {
     av_bsf_free(&s->h264_bsf_ctx);

--- a/c_src/membrane_rtmp_plugin/source/rtmp_source.h
+++ b/c_src/membrane_rtmp_plugin/source/rtmp_source.h
@@ -16,7 +16,7 @@ typedef struct State State;
 struct State {
   AVFormatContext *input_ctx;
   int number_of_streams;
-  bool ready;
+  bool terminating;
 
   AVBSFContext *h264_bsf_ctx;
 };

--- a/c_src/membrane_rtmp_plugin/source/rtmp_source.spec.exs
+++ b/c_src/membrane_rtmp_plugin/source/rtmp_source.spec.exs
@@ -3,11 +3,18 @@ module Membrane.RTMP.Source.Native
 state_type "State"
 interface [NIF]
 
-spec native_create(string, timeout :: string) ::
-       {:ok :: label, state} | {:error :: label, reason :: string}
+spec create() :: {:ok :: label, state}
+
+spec await_open(state, url :: string, timeout :: int) ::
+       {:ok :: label, state}
+       | {:error :: label, :timeout :: label}
+       | {:error :: label, :interrupted :: label}
+       | {:error :: label, reason :: string}
 
 spec get_video_params(state) :: {:ok :: label, params :: payload} | {:error :: label, :no_stream}
 spec get_audio_params(state) :: {:ok :: label, params :: payload} | {:error :: label, :no_stream}
+
+spec set_terminate(state) :: :ok :: label
 
 spec read_frame(state) ::
        {:ok, :audio :: label, pts :: int64, dts :: int64, frame :: payload}
@@ -15,4 +22,4 @@ spec read_frame(state) ::
        | {:error :: label, reason :: string}
        | (:end_of_stream :: label)
 
-dirty :io, native_create: 2, read_frame: 1
+dirty :io, await_open: 3, read_frame: 1

--- a/lib/membrane_rtmp_plugin/rtmp/source/native.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/native.ex
@@ -31,6 +31,6 @@ defmodule Membrane.RTMP.Source.Native do
   end
 
   defp get_int_timeout(time) do
-    Time.as_seconds(time) |> Ratio.trunc()
+    time |> Time.as_seconds() |> Ratio.trunc()
   end
 end

--- a/test/membrane_rtmp_plugin/rtmp_source_test.exs
+++ b/test/membrane_rtmp_plugin/rtmp_source_test.exs
@@ -9,39 +9,48 @@ defmodule Membrane.RTMP.Source.Test do
 
   @input_file "test/fixtures/testsrc.flv"
   @port 9009
-  @output_path "rtmp://localhost:#{@port}"
+  @rtmp_stream_url "rtmp://127.0.0.1:#{@port}/"
 
-  setup do
-    pipeline_pid = get_testing_pipeline() |> start_supervised!()
+  test "Check if the stream started and that it ends" do
+    assert {:ok, pipeline} = get_testing_pipeline()
+    assert_pipeline_playback_changed(pipeline, :prepared, :playing)
 
-    %{
-      pid: pipeline_pid,
-      ffmpeg:
-        start_supervised!(%{
-          id: :ffmpeg,
-          start: {__MODULE__, :start_ffmpeg, []}
-        })
-    }
-  end
+    ffmpeg_task = Task.async(&start_ffmpeg/0)
 
-  test "Check if the stream started and that it ends", %{pid: pid} do
-    assert_pipeline_playback_changed(pid, :prepared, :playing, 10_000)
-    assert_sink_buffer(pid, :video_sink, %Membrane.Buffer{})
-    assert_sink_buffer(pid, :audio_sink, %Membrane.Buffer{})
-    assert_end_of_stream(pid, :audio_sink, :input, 11_000)
-    assert_end_of_stream(pid, :video_sink, :input)
+    assert_sink_buffer(pipeline, :video_sink, %Membrane.Buffer{})
+    assert_sink_buffer(pipeline, :audio_sink, %Membrane.Buffer{})
+    assert_end_of_stream(pipeline, :audio_sink, :input, 11_000)
+    assert_end_of_stream(pipeline, :video_sink, :input)
 
     # Cleanup
-    Membrane.Testing.Pipeline.terminate(pid, blocking?: true)
-    stop_supervised(:ffmpeg)
+    Pipeline.terminate(pipeline, blocking?: true)
+    assert :ok = Task.await(ffmpeg_task)
+  end
+
+  test "blocking calls are cancelled properly" do
+    alias Membrane.RTMP.Source.Native
+    assert {:ok, native} = Native.create()
+
+    pid =
+      spawn(fn ->
+        Native.await_connection(native, @rtmp_stream_url, :infinity)
+      end)
+
+    Process.sleep(100)
+    Process.exit(pid, :shutdown)
+    Process.sleep(100)
+
+    # Ensure the ffmpeg does not listen on this port anymore
+    assert :gen_tcp.connect('127.0.0.1', @port, [:binary]) == {:error, :econnrefused}
   end
 
   defp get_testing_pipeline() do
     import Membrane.ParentSpec
+    timeout = Membrane.Time.seconds(10)
 
     options = [
       children: [
-        src: %Membrane.RTMP.SourceBin{port: @port},
+        src: %Membrane.RTMP.SourceBin{port: @port, timeout: timeout},
         audio_sink: Testing.Sink,
         video_sink: Testing.Sink
       ],
@@ -52,19 +61,10 @@ defmodule Membrane.RTMP.Source.Test do
       test_process: self()
     ]
 
-    %{
-      id: :test_pipeline,
-      start: {Pipeline, :start_link, [options]}
-    }
+    Pipeline.start_link(options)
   end
 
-  @spec start_ffmpeg() :: {:ok, pid()}
-  def start_ffmpeg() do
-    spawn_link(&execute_loop/0)
-    |> then(&{:ok, &1})
-  end
-
-  defp execute_loop() do
+  defp start_ffmpeg() do
     import FFmpex
     use FFmpex.Options
     Logger.debug("Starting ffmpeg")
@@ -74,18 +74,18 @@ defmodule Membrane.RTMP.Source.Test do
       |> add_global_option(option_y())
       |> add_input_file(@input_file)
       |> add_file_option(option_re())
-      |> add_output_file(@output_path)
+      |> add_output_file(@rtmp_stream_url)
       |> add_file_option(option_f("flv"))
       |> add_file_option(option_vcodec("copy"))
       |> add_file_option(option_acodec("copy"))
 
     case FFmpex.execute(command) do
-      :ok ->
+      {:ok, ""} ->
         :ok
 
       error ->
         Logger.error(inspect(error))
-        execute_loop()
+        :error
     end
   end
 end


### PR DESCRIPTION
Should be merged after #18

Fixes a serious problem where `RTMP.Source` would listen forever for a connection, essentially disabling the port it is using until the VM is restarted