### PR TITLE
Retry connection on timeout

### DIFF
--- a/c_src/membrane_rtmp_plugin/sink/rtmp_sink.c
+++ b/c_src/membrane_rtmp_plugin/sink/rtmp_sink.c
@@ -30,6 +30,8 @@ UNIFEX_TERM try_connect(UnifexEnv *env, State *state) {
     int av_err = avio_open(&state->output_ctx->pb, rtmp_url, AVIO_FLAG_WRITE);
     if (av_err == AVERROR(ECONNREFUSED)) {
       return try_connect_result_error_econnrefused(env);
+    } else if (av_err == AVERROR(ETIMEDOUT)) {
+      return try_connect_result_error_etimedout(env);
     } else if (av_err < 0) {
       return try_connect_result_error(env, av_err2str(av_err));
     }

--- a/c_src/membrane_rtmp_plugin/sink/rtmp_sink.spec.exs
+++ b/c_src/membrane_rtmp_plugin/sink/rtmp_sink.spec.exs
@@ -8,6 +8,7 @@ spec create(rtmp_url :: string) :: {:ok :: label, state} | {:error :: label, rea
 spec try_connect(state) ::
        (:ok :: label)
        | {:error :: label, :econnrefused :: label}
+       | {:error :: label, :etimedout :: label}
        | {:error :: label, reason :: string}
 
 spec finalize_stream(state) :: :ok :: label

--- a/lib/membrane_rtmp_plugin/rtmp/sink/sink.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/sink/sink.ex
@@ -177,7 +177,7 @@ defmodule Membrane.RTMP.Sink do
         demands = ctx.pads |> Map.keys() |> Enum.map(&{:demand, &1})
         {{:ok, [{:playback_change, :resume} | demands]}, state}
 
-      {:error, :econnrefused} ->
+      {:error, error} when error in [:econnrefused, :etimedout] ->
         Process.send_after(self(), :try_connect, @connection_attempt_interval)
 
         Membrane.Logger.warn(


### PR DESCRIPTION
We are using AWS MediaLive as a RTMP destination and while the channel is in the starting phase, the connection fails with a `ETIMEDOUT` error. In order to make the retry work in that case, I've added the error code.