### PR TITLE
Remove pattern match on request_packet call

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
@@ -197,7 +197,7 @@ defmodule Membrane.RTMP.MessageHandler do
   end
 
   defp request_packet(socket) do
-    :ok = :inet.setopts(socket, active: :once)
+    :inet.setopts(socket, active: :once)
   end
 
   defp get_media_actions(rtmp_header, data, state) do

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -109,7 +109,7 @@ defmodule Membrane.RTMP.Source do
 
   @impl true
   def handle_demand(_pad, _size, _unit, _ctx, state) when state.socket_ready? do
-    :ok = :inet.setopts(state.socket, active: :once)
+    :inet.setopts(state.socket, active: :once)
     {:ok, state}
   end
 


### PR DESCRIPTION
A call to `:inet.setopts` can return either `:ok` or `{:error, posix_code}`.

 When using the socket inside`Membrane.RTMP.MessageHandler` we always pattern matched on `:ok` when requesting another packet. This happened not to be a good idea since it happens sometimes that when requesting the next packet the socket can already be closed. 

Since the `Source` element gets a message when the socket gets closed we can safely ignore the error and let the source handle the socket once we finish processing the RTMP messages. 