### PR TITLE
Add timestamp delta persistence between packet headers

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_rtmp_plugin, "~> 0.11.0"}
+    {:membrane_rtmp_plugin, "~> 0.11.1"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/header.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/header.ex
@@ -2,7 +2,7 @@ defmodule Membrane.RTMP.Header do
   @moduledoc false
 
   @enforce_keys [:chunk_stream_id, :type_id]
-  defstruct @enforce_keys ++ [body_size: 0, timestamp: 0, stream_id: 0]
+  defstruct @enforce_keys ++ [body_size: 0, timestamp: 0, timestamp_delta: 0, stream_id: 0]
 
   @typedoc """
   RTMP header structure.
@@ -83,6 +83,7 @@ defmodule Membrane.RTMP.Header do
     header = %__MODULE__{
       chunk_stream_id: chunk_stream_id,
       timestamp: previous_headers[chunk_stream_id].timestamp + timestamp_delta,
+      timestamp_delta: timestamp_delta,
       body_size: body_size,
       type_id: type_id,
       stream_id: previous_headers[chunk_stream_id].stream_id
@@ -98,6 +99,7 @@ defmodule Membrane.RTMP.Header do
     header = %__MODULE__{
       chunk_stream_id: chunk_stream_id,
       timestamp: previous_headers[chunk_stream_id].timestamp + timestamp_delta,
+      timestamp_delta: timestamp_delta,
       body_size: previous_headers[chunk_stream_id].body_size,
       type_id: previous_headers[chunk_stream_id].type_id,
       stream_id: previous_headers[chunk_stream_id].stream_id
@@ -110,12 +112,11 @@ defmodule Membrane.RTMP.Header do
         <<@header_type_3::bitstring, chunk_stream_id::6, rest::binary>>,
         previous_headers
       ) do
+    previous_header = previous_headers[chunk_stream_id]
+
     header = %__MODULE__{
-      chunk_stream_id: chunk_stream_id,
-      timestamp: previous_headers[chunk_stream_id].timestamp,
-      body_size: previous_headers[chunk_stream_id].body_size,
-      type_id: previous_headers[chunk_stream_id].type_id,
-      stream_id: previous_headers[chunk_stream_id].stream_id
+      previous_header
+      | timestamp: previous_header.timestamp + previous_header.timestamp_delta
     }
 
     {header, rest}

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.11.0"
+  @version "0.11.1"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do

--- a/mix.exs
+++ b/mix.exs
@@ -10,7 +10,7 @@ defmodule Membrane.RTMP.Mixfile do
       version: @version,
       elixir: "~> 1.12",
       elixirc_paths: elixirc_paths(Mix.env()),
-      compilers: [:unifex, :bundlex] ++ Mix.compilers(),
+      compilers: [:unifex, :bundlex] ++ Mix.compilers() ++ maybe_add_rambo(),
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       dialyzer: dialyzer(),
@@ -67,6 +67,13 @@ defmodule Membrane.RTMP.Mixfile do
     else
       opts
     end
+  end
+
+  # for Mac M1 it is necessary to include rambo compiler (used by :ffmpex)
+  if Mix.env() == :test do
+    def maybe_add_rambo(), do: [:rambo]
+  else
+    def maybe_add_rambo(), do: []
   end
 
   defp package do

--- a/test/membrane_rtmp_plugin/rtmp_source_bin_test.exs
+++ b/test/membrane_rtmp_plugin/rtmp_source_bin_test.exs
@@ -14,7 +14,7 @@ defmodule Membrane.RTMP.SourceBin.IntegrationTest do
 
   @stream_length_ms 3000
   @video_frame_duration_ms 42
-  @audio_frame_duration_ms 23
+  @audio_frame_duration_ms 24
 
   test "SourceBin outputs the correct number of audio and video buffers" do
     {:ok, port} = start_tcp_server()


### PR DESCRIPTION
Accordingly to the RTMP spec we were missing reusing a timestamp delta for `TYPE 3` packets which resulted
in timestamp duplication between following packets which with audio and video resulted in a timestamp drift that could never be recovered.