### PR TITLE
Avoid enforcing duration, file_size and encoder presence

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/set_data_frame.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/set_data_frame.ex
@@ -7,9 +7,7 @@ defmodule Membrane.RTMP.Messages.SetDataFrame do
 
   alias Membrane.RTMP.AMF.Encoder
 
-  @enforce_keys [:duration, :file_size, :encoder]
-  defstruct @enforce_keys ++
-              ~w(width height video_codec_id video_data_rate framerate audio_codec_id
+  defstruct ~w(duration file_size encoder width height video_codec_id video_data_rate framerate audio_codec_id
                 audio_data_rate audio_sample_rate audio_sample_size stereo)a
 
   @attributes_to_keys %{


### PR DESCRIPTION
This fixes https://github.com/membraneframework/membrane_rtmp_plugin/issues/45 and makes it possible to ingest an RTMP stream created by AWS Medialive in a Membrane pipeline. Notice also that while ffmpeg does deliver those keys/value pairs in its AMF payload they are set to 0.0 except for the encoder. We don't foresee any unwelcome side effect.