### PR TITLE
Send end_of_stream on deleteStream message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_rtmp_plugin, "~> 0.12.0"}
+    {:membrane_rtmp_plugin, "~> 0.12.1"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
@@ -187,8 +187,7 @@ defmodule Membrane.RTMP.MessageHandler do
   end
 
   defp do_handle_client_message(%Messages.Anonymous{name: "deleteStream"}, _header, state) do
-    # We could send `:end_of_stream` here, however more reliable method is to wait for `:tcp_closed` message on the socket.
-    {:cont, state}
+    {:cont, %{state | actions: [{:end_of_stream, :output} | state.actions]}}
   end
 
   defp do_handle_client_message(%Messages.Anonymous{} = message, _header, state) do

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_validator.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_validator.ex
@@ -6,7 +6,7 @@ defprotocol Membrane.RTMP.MessageValidator do
   of the RTMP messages.
   """
 
-  @type validation_result_t :: {:ok, binary()} | {:error, reason :: any()}
+  @type validation_result_t :: {:ok, term()} | {:error, reason :: any()}
 
   @doc """
   Validates the `t:Membrane.RTMP.Messages.ReleaseStream.t/0` message.

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -222,10 +222,10 @@ defmodule Membrane.RTMP.Source do
 
   @impl true
   def handle_info({:socket_closed, _socket}, ctx, state) do
-    if ctx.pads.output.start_of_stream? do
-      {[end_of_stream: :output], state}
-    else
-      {[notify_parent: :unexpected_socket_closed], state}
+    cond do
+      ctx.pads.output.end_of_stream? -> {[], state}
+      ctx.pads.output.start_of_stream? -> {[end_of_stream: :output], state}
+      true -> {[notify_parent: :unexpected_socket_closed], state}
     end
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -223,8 +223,7 @@ defmodule Membrane.RTMP.Source do
   @impl true
   def handle_info({:socket_closed, _socket}, ctx, state) do
     if ctx.pads.output.start_of_stream? do
-      # EOS is handled by the message handler.
-      {[], state}
+      {[end_of_stream: :output], state}
     else
       {[notify_parent: :unexpected_socket_closed], state}
     end

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -223,7 +223,8 @@ defmodule Membrane.RTMP.Source do
   @impl true
   def handle_info({:socket_closed, _socket}, ctx, state) do
     if ctx.pads.output.start_of_stream? do
-      {[end_of_stream: :output], state}
+      # EOS is handled by the message handler.
+      {[], state}
     else
       {[notify_parent: :unexpected_socket_closed], state}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.12.0"
+  @version "0.12.1"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR adds end_of_stream action in case of deleteStream and remove end_of_stream action
when the TCP connection is closed. Closes #52
