### PR TITLE
Change Logger.error into Logger.warn for informing about stream format redefinition

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-    {:membrane_rtmp_plugin, "~> 0.13.0"}
+    {:membrane_rtmp_plugin, "~> 0.13.1"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/sink/sink.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/sink/sink.ex
@@ -139,7 +139,7 @@ defmodule Membrane.RTMP.Sink do
         {[], %{state | native: native, ready?: ready?}}
 
       {:error, :stream_format_resent} ->
-        Membrane.Logger.error(
+        Membrane.Logger.warn(
           "Input stream format redefined on pad :video. RTMP Sink does not support dynamic stream parameters"
         )
 
@@ -168,7 +168,7 @@ defmodule Membrane.RTMP.Sink do
         {[], %{state | native: native, ready?: ready?}}
 
       {:error, :stream_format_resent} ->
-        Membrane.Logger.error(
+        Membrane.Logger.warn(
           "Input stream format redefined on pad :audio. RTMP Sink does not support dynamic stream parameters"
         )
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.13.0"
+  @version "0.13.1"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
[DESCRIPTION OF CHANGES]
The "Input stream format redefined on pad *. RTMP Sink does not support dynamic stream parameters." error has been transformed into a warning message, since there is nothing RTMP Sink can do once it has already sent some metadata at the beginning of the stream, and in some cases, the stream might not be corrupted and work properly, even though the parameters seem to have changed - so there is no need to frighten the users.

[EXPLANATION]
The case exists e.g. with MP4 to RTMP pipeline, for files where the SPS and PPS parameters NAL units are available both in the “decoder configuration record” and in-band of the stream. Once the depayloader depayloads the stream, it puts the SPS and PPS from the “decoder configuration record” at the beginning of the stream. Right after the newly put (SPS PPS) parameters, there is a (SPS PPS) sequence that have been in-band of the stream. In the next step that causes the payloader to consider the sequence (SPS PPS) (SPS PPS) as parameters for the stream and such a sequence gets put to the .flv metadata in the RTMP Sink. However, when the stream continues, the new (SPS PPS) in-band parameters sequence is processed by the payloader and the payloader then thinks, that the parameters have changed since they used to be (SPS PPS)(SPS PPS) and now they are just (SPS PPS). The payloader notifies the RTMP Sink that the parameters have changed and RTMP Sink prints an error, despite the fact, that the parameters are just repeated.
That error isn’t causing the pipeline to fail, nor it’s unavoidable that the the stream is corrupted once the error is printed.
