### PR TITLE
Send to parent the RTMP connect message

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
@@ -76,7 +76,7 @@ defmodule Membrane.RTMP.MessageHandler do
     {:cont, %{state | message_parser: parser}}
   end
 
-  defp do_handle_client_message(%Messages.Connect{}, _header, state) do
+  defp do_handle_client_message(%Messages.Connect{} = connect, _header, state) do
     chunk_size = state.message_parser.chunk_size
 
     [
@@ -98,7 +98,12 @@ defmodule Membrane.RTMP.MessageHandler do
     Responses.on_bw_done()
     |> send_rtmp_payload(state.socket, chunk_size, chunk_stream_id: 3)
 
-    {:cont, %{state | message_parser: message_parser}}
+    {:cont,
+     %{
+       state
+       | message_parser: message_parser,
+         actions: state.actions ++ [{:notify_parent, {:rtmp_connect_message, connect}}]
+     }}
   end
 
   # According to ffmpeg's documentation, this command should make the server release channel for a media stream


### PR DESCRIPTION
Hey team, this is not really a finished PR but something that I would like to have from this library.
In this PR I'm modifying the message_handler to send the RTMP.Message.Connect to the parent as a notification.
I found it useful in one of my project where I can target my RTMP server with urls like this `rtmp://localhost:<port>/?some_id=AAA` and I can get this ID into my pipeline.
If there is another way to do it I'm happy to explore it too :)
Off course if you like this idea we can add test and doc :)

Thanks !