### PR TITLE
Add support for `additionalMedia` message

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.20.2"}
+	  {:membrane_rtmp_plugin, "~> 0.22.0"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/amf0/encoder.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/amf0/encoder.ex
@@ -1,4 +1,4 @@
-defmodule Membrane.RTMP.AMF.Encoder do
+defmodule Membrane.RTMP.AMF0.Encoder do
   @moduledoc false
 
   @type basic_object_t :: float() | boolean() | String.t() | map() | :null

--- a/lib/membrane_rtmp_plugin/rtmp/source/amf0/parser.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/amf0/parser.ex
@@ -61,8 +61,9 @@ defmodule Membrane.RTMP.AMF0.Parser do
     {Enum.reverse(acc), rest}
   end
 
+  # switch to AMF3
   defp parse_value(<<0x11, rest::binary>>) do
-    AMF3.Parser.parse(rest)
+    AMF3.Parser.parse_one(rest)
   end
 
   defp parse_value(data) do

--- a/lib/membrane_rtmp_plugin/rtmp/source/amf3/parser.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/amf3/parser.ex
@@ -1,0 +1,216 @@
+defmodule Membrane.RTMP.AMF3.Parser do
+  @moduledoc false
+
+  import Bitwise
+
+  @doc """
+  Parses message from AMF3 format to elixir data types.
+  """
+  @spec parse_list(binary()) :: list()
+  def parse_list(binary) do
+    do_parse(binary, [])
+  end
+
+  @doc """
+  Parses message from AMF3 format to elixir data type.
+  """
+  @spec parse(binary()) :: {value :: term(), rest :: binary()}
+  def parse(binary) do
+    parse_value(binary)
+  end
+
+  defp do_parse(<<>>, acc), do: Enum.reverse(acc)
+
+  defp do_parse(payload, acc) do
+    {value, rest} = parse_value(payload)
+
+    do_parse(rest, [value | acc])
+  end
+
+  # undefined
+  defp parse_value(<<0x00, rest::binary>>) do
+    {:undefined, rest}
+  end
+
+  # null
+  defp parse_value(<<0x01, rest::binary>>) do
+    {nil, rest}
+  end
+
+  # false
+  defp parse_value(<<0x02, rest::binary>>) do
+    {false, rest}
+  end
+
+  # true
+  defp parse_value(<<0x03, rest::binary>>) do
+    {true, rest}
+  end
+
+  # integer
+  defp parse_value(<<0x04, rest::binary>>) do
+    parse_integer(rest)
+  end
+
+  # double
+  defp parse_value(<<0x05, double::float-size(64), rest::binary>>) do
+    {double, rest}
+  end
+
+  # string
+  defp parse_value(<<0x06, rest::binary>>) do
+    parse_string(rest)
+  end
+
+  # xml document
+  defp parse_value(<<0x07, rest::binary>>) do
+    {size, rest} = parse_integer(rest)
+
+    # if the bit is set then we are dealing with string literal
+    if (size &&& 0x01) == 1 do
+      size = size >>> 1
+
+      <<string::binary-size(size), rest::binary>> = rest
+
+      {{:xml_doc, string}, rest}
+    else
+      raise "Unsupported xml doc reference"
+    end
+  end
+
+  # date
+  defp parse_value(<<0x08, rest::binary>>) do
+    {number, rest} = parse_integer(rest)
+
+    if (number &&& 0x01) == 1 do
+      {{:date, :previous}, rest}
+    else
+      <<date::float-size(64), rest::binary>> = rest
+
+      {{:date, date}, rest}
+    end
+  end
+
+  # array
+  defp parse_value(<<0x09, rest::binary>>) do
+    {size, rest} = parse_integer(rest)
+
+    if (size &&& 0x01) == 1 do
+      dense_array_size = size >>> 1
+
+      {assoc_array, rest} = parse_assoc_array(rest, [])
+      {dense_array, rest} = parse_dense_array(rest, dense_array_size, [])
+
+      {assoc_array ++ dense_array, rest}
+    else
+      raise "Unsupported array reference"
+    end
+  end
+
+  # object
+  defp parse_value(<<0x0A, _rest::binary>>) do
+    raise "Unsupported object type"
+  end
+
+  # xml
+  defp parse_value(<<0x0B, rest::binary>>) do
+    {size, rest} = parse_integer(rest)
+
+    # if the bit is set then we are dealing with string literal
+    if (size &&& 0x01) == 1 do
+      size = size >>> 1
+
+      <<string::binary-size(size), rest::binary>> = rest
+
+      {{:xml, string}, rest}
+    else
+      raise "Unsupported xml reference"
+    end
+  end
+
+  # byte array
+  defp parse_value(<<0x0C, rest::binary>>) do
+    {size, rest} = parse_integer(rest)
+
+    if (size &&& 0x01) == 1 do
+      size = size >>> 1
+
+      <<bytes::binary-size(size), rest::binary>> = rest
+
+      {bytes, rest}
+    else
+      raise "Unsupported byte array reference"
+    end
+  end
+
+  # vector int
+  defp parse_value(<<0x0D, _rest::binary>>) do
+    raise "Unsupported vector int type"
+  end
+
+  # vector uint
+  defp parse_value(<<0x0E, _rest::binary>>) do
+    raise "Unsupported vector uint type"
+  end
+
+  # vector double
+  defp parse_value(<<0x0F, _rest::binary>>) do
+    raise "Unsupported vector double type"
+  end
+
+  # vector object
+  defp parse_value(<<0x10, _rest::binary>>) do
+    raise "Unsupported vector object type"
+  end
+
+  # dictionary
+  defp parse_value(<<0x11, _rest::binary>>) do
+    raise "Unsupported dictionary type"
+  end
+
+  defp parse_integer(<<0::1, value::7, rest::binary>>), do: {value, rest}
+
+  defp parse_integer(<<1::1, first::7, 0::1, second::7, rest::binary>>) do
+    {bsl(first, 7) + second, rest}
+  end
+
+  defp parse_integer(<<1::1, first::7, 1::1, second::7, 0::1, third::7, rest::binary>>) do
+    {bsl(first, 14) + bsl(second, 7) + third, rest}
+  end
+
+  defp parse_integer(<<1::1, first::7, 1::1, second::7, 0::1, third::7, fourth::8, rest::binary>>) do
+    {bsl(first, 22) + bsl(second, 15) + bsl(third, 7) + fourth, rest}
+  end
+
+  defp parse_string(payload) do
+    {size, rest} = parse_integer(payload)
+
+    # if the bit is set then we are dealing with string literal
+    if (size &&& 0x01) == 1 do
+      size = size >>> 1
+
+      <<string::binary-size(size), rest::binary>> = rest
+
+      {string, rest}
+    else
+      raise "Unsupported string reference"
+    end
+  end
+
+  defp parse_assoc_array(<<0x01, rest::binary>>, acc), do: {Enum.reverse(acc), rest}
+
+  defp parse_assoc_array(payload, acc) do
+    {key, rest} = parse_string(payload)
+    {value, rest} = parse_value(rest)
+
+    parse_assoc_array(rest, [{key, value} | acc])
+  end
+
+  defp parse_dense_array(rest, 0, acc), do: {Enum.reverse(acc), rest}
+
+  defp parse_dense_array(rest, size, acc) do
+    {value, rest} = parse_value(rest)
+
+    parse_dense_array(rest, size - 1, [value | acc])
+  end
+end

--- a/lib/membrane_rtmp_plugin/rtmp/source/message.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message.ex
@@ -34,7 +34,8 @@ defmodule Membrane.RTMP.Message do
 
   @amf_data_to_module %{
     "@setDataFrame" => Messages.SetDataFrame,
-    "onMetaData" => Messages.OnMetaData
+    "onMetaData" => Messages.OnMetaData,
+    "additionalMedia" => Messages.AdditionalMedia
   }
 
   @spec deserialize_message(type_id :: integer(), binary()) :: struct()
@@ -88,7 +89,7 @@ defmodule Membrane.RTMP.Message do
 
   defp message_from_modules(payload, mapping, required? \\ false) do
     payload
-    |> Membrane.RTMP.AMF.Parser.parse()
+    |> Membrane.RTMP.AMF0.Parser.parse()
     |> then(fn [command | _rest] = arguments ->
       if required? do
         Map.fetch!(mapping, command)

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_handler.ex
@@ -68,6 +68,11 @@ defmodule Membrane.RTMP.MessageHandler do
     {:cont, state}
   end
 
+  defp do_handle_client_message(%Messages.AdditionalMedia{} = media, header, state) do
+    state = get_additional_media_actions(header, media, state)
+    {:cont, state}
+  end
+
   defp do_handle_client_message(%Handshake.Step{type: :s0_s1_s2} = step, _header, state) do
     state.socket_module.send(state.socket, Handshake.Step.serialize(step))
 
@@ -146,6 +151,21 @@ defmodule Membrane.RTMP.MessageHandler do
   @validation_stage :set_data_frame
   defp do_handle_client_message(%Messages.SetDataFrame{} = data_frame, _header, state) do
     case MessageValidator.validate_set_data_frame(state.validator, data_frame) do
+      {:ok, _msg} = result ->
+        {:cont, validation_action(state, @validation_stage, result)}
+
+      {:error, _reason} = error ->
+        {:halt, {:error, :stream_validation, validation_action(state, @validation_stage, error)}}
+    end
+  end
+
+  @validation_stage :on_expect_additional_media
+  defp do_handle_client_message(
+         %Messages.OnExpectAdditionalMedia{} = additional_media,
+         _header,
+         state
+       ) do
+    case MessageValidator.validate_on_expect_additional_media(state.validator, additional_media) do
       {:ok, _msg} = result ->
         {:cont, validation_action(state, @validation_stage, result)}
 
@@ -258,30 +278,57 @@ defmodule Membrane.RTMP.MessageHandler do
     }
   end
 
+  defp get_additional_media_actions(rtmp_header, media, %{header_sent?: true} = state) do
+    # NOTE: we are replacing the type_id from 18 to 8 (script data to audio data) as it carries the
+    # additional audio track
+    header = %Membrane.RTMP.Header{rtmp_header | type_id: 8, body_size: byte_size(media.media)}
+
+    # NOTE: for additional media we are also setting the stream_id to 1.
+    # It is against the spec but it simplifies things for us since we don't have to
+    # handle dynamic pads in the RTMP source + our FLV demuxer handles that well.
+    payload = get_flv_tag(header, 1, media.media)
+
+    action = {:buffer, {:output, %Buffer{payload: payload}}}
+
+    Map.update!(state, :actions, &[action | &1])
+  end
+
+  defp get_additional_media_actions(rtmp_header, media, state) do
+    header = %Membrane.RTMP.Header{rtmp_header | type_id: 8, body_size: byte_size(media.media)}
+    payload = get_flv_header() <> get_flv_tag(header, 1, media.media)
+
+    action = {:buffer, {:output, %Buffer{payload: payload}}}
+
+    %{state | header_sent?: true, actions: [action | state.actions]}
+  end
+
   defp get_flv_header() do
     alias Membrane.FLV
 
     {header, 0} =
-      FLV.Serializer.serialize(%FLV.Header{audio_present?: true, video_present?: true}, 0)
+      FLV.Serializer.serialize(
+        %FLV.Header{audio_present?: true, video_present?: true},
+        0
+      )
 
     # Add PreviousTagSize, which is 0 for the first tag
     header <> <<0::32>>
   end
 
+  # according to the FLV spec, the stream ID should always be 0
+  # but we can use 1 for hacking around Twitch's addtional audio stream
   defp get_flv_tag(
          %Membrane.RTMP.Header{
            timestamp: timestamp,
            body_size: data_size,
            type_id: type_id
          },
+         stream_id \\ 0,
          payload
        ) do
     tag_size = data_size + 11
 
     <<upper_timestamp::8, lower_timestamp::24>> = <<timestamp::32>>
-
-    # according to the FLV spec, the stream ID should always be 0
-    stream_id = 0
 
     <<type_id::8, data_size::24, lower_timestamp::24, upper_timestamp::8, stream_id::24,
       payload::binary-size(data_size), tag_size::32>>

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_validator.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_validator.ex
@@ -33,6 +33,13 @@ defprotocol Membrane.RTMP.MessageValidator do
   def validate_set_data_frame(impl, message)
 
   @doc """
+  Validates the `t:Membrane.RTMP.Messages.OnExpectAdditionalMedia.t/0` message.
+  """
+  @spec validate_on_expect_additional_media(t(), Messages.OnExpectAdditionalMedia.t()) ::
+          validation_result_t()
+  def validate_on_expect_additional_media(impl, message)
+
+  @doc """
   Validates the `t:Membrane.RTMP.Messages.OnMetaData.t/0` message.
   """
   @spec validate_on_meta_data(t(), Messages.OnMetaData.t()) :: validation_result_t()

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_validator/default.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_validator/default.ex
@@ -20,5 +20,9 @@ defimpl Membrane.RTMP.MessageValidator, for: Membrane.RTMP.MessageValidator.Defa
   def validate_set_data_frame(_impl, _message), do: {:ok, "set data frame success"}
 
   @impl true
+  def validate_on_expect_additional_media(_impl, _message),
+    do: {:ok, "on expect additional media success"}
+
+  @impl true
   def validate_on_meta_data(_impl, _message), do: {:ok, "on meta data success"}
 end

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/additional_media.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/additional_media.ex
@@ -1,0 +1,39 @@
+defmodule Membrane.RTMP.Messages.AdditionalMedia do
+  @moduledoc false
+
+  @behaviour Membrane.RTMP.Message
+
+  alias Membrane.RTMP.AMF0.Encoder
+
+  @enforce_keys [:id, :media]
+  defstruct @enforce_keys
+
+  @type t :: %__MODULE__{
+          id: String.t(),
+          media: binary()
+        }
+
+  @impl true
+  def from_data(["additionalMedia", %{"id" => id, "media" => media}]) do
+    %__MODULE__{id: id, media: media}
+  end
+
+  @doc false
+  @spec to_map(t()) :: map()
+  def to_map(%__MODULE__{id: id, media: media}) do
+    # TODO: this media should be AMF3 encoded
+    %{"id" => id, "media" => media}
+  end
+
+  defimpl Membrane.RTMP.Messages.Serializer do
+    require Membrane.RTMP.Header
+
+    @impl true
+    def serialize(%@for{} = message) do
+      Encoder.encode([@for.to_map(message)])
+    end
+
+    @impl true
+    def type(%@for{}), do: Membrane.RTMP.Header.type(:amf_data)
+  end
+end

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/anonymous.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/anonymous.ex
@@ -26,7 +26,7 @@ defmodule Membrane.RTMP.Messages.Anonymous do
   defimpl Membrane.RTMP.Messages.Serializer do
     require Membrane.RTMP.Header
 
-    alias Membrane.RTMP.AMF.Encoder
+    alias Membrane.RTMP.AMF0.Encoder
 
     @impl true
     def serialize(%@for{name: name, tx_id: nil, properties: properties}) do

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
@@ -5,7 +5,7 @@ defmodule Membrane.RTMP.Messages.Connect do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   @enforce_keys [:app, :tc_url]
   defstruct @enforce_keys ++

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/create_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/create_stream.ex
@@ -3,7 +3,7 @@ defmodule Membrane.RTMP.Messages.CreateStream do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   defstruct tx_id: 0
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/delete_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/delete_stream.ex
@@ -3,7 +3,7 @@ defmodule Membrane.RTMP.Messages.DeleteStream do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   @enforce_keys [:stream_id]
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/fc_publish.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/fc_publish.ex
@@ -3,7 +3,7 @@ defmodule Membrane.RTMP.Messages.FCPublish do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   @enforce_keys [:stream_key]
   defstruct [tx_id: 0] ++ @enforce_keys

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/publish.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/publish.ex
@@ -5,7 +5,7 @@ defmodule Membrane.RTMP.Messages.Publish do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   @enforce_keys [:stream_key]
   defstruct [:publish_type, tx_id: 0] ++ @enforce_keys

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/release_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/release_stream.ex
@@ -5,7 +5,7 @@ defmodule Membrane.RTMP.Messages.ReleaseStream do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
 
   @enforce_keys [:stream_key]
   defstruct [tx_id: 0] ++ @enforce_keys

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/on_expect_additional_media.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/on_expect_additional_media.ex
@@ -1,6 +1,10 @@
-defmodule Membrane.RTMP.Messages.OnMetaData do
+defmodule Membrane.RTMP.Messages.OnExpectAdditionalMedia do
   @moduledoc """
-  Defines the RTMP `onMetaData` command (sent by nginx client).
+  Defines the RTMP `onExpectAdditionalMedia` command that is related to Twitch's RTMP additional
+  media track message.
+
+  The command is usually a part of `@setDataFrame` command but for more convencience it is
+  extracted.
   """
 
   @behaviour Membrane.RTMP.Message
@@ -8,14 +12,9 @@ defmodule Membrane.RTMP.Messages.OnMetaData do
   alias Membrane.RTMP.AMF0.Encoder
 
   @attributes_to_keys %{
-    "duration" => :duration,
-    "width" => :width,
-    "height" => :height,
-    "videocodecid" => :video_codec_id,
-    "videodatarate" => :video_data_rate,
-    "framerate" => :framerate,
-    "audiocodecid" => :audio_codec_id,
-    "audiodatarate" => :audio_data_rate
+    "additionalMedia" => :additional_media,
+    "defaultMedia" => :default_media,
+    "processingIntents" => :processing_intents
   }
 
   @keys_to_attributes Map.new(@attributes_to_keys, fn {key, value} -> {value, key} end)
@@ -23,20 +22,13 @@ defmodule Membrane.RTMP.Messages.OnMetaData do
   defstruct Map.keys(@keys_to_attributes)
 
   @type t :: %__MODULE__{
-          duration: number(),
-          # video related
-          width: number(),
-          height: number(),
-          video_codec_id: number(),
-          video_data_rate: number(),
-          framerate: number(),
-          # audio related
-          audio_codec_id: number(),
-          audio_data_rate: number()
+          additional_media: map(),
+          default_media: map(),
+          processing_intents: [String.t()]
         }
 
   @impl true
-  def from_data(["onMetaData", properties]) do
+  def from_data(["@setDataFrame", "onExpectAdditionalMedia", properties]) do
     new(properties)
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/set_data_frame.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/set_data_frame.ex
@@ -5,7 +5,8 @@ defmodule Membrane.RTMP.Messages.SetDataFrame do
 
   @behaviour Membrane.RTMP.Message
 
-  alias Membrane.RTMP.AMF.Encoder
+  alias Membrane.RTMP.AMF0.Encoder
+  alias Membrane.RTMP.Messages.OnExpectAdditionalMedia
 
   defstruct ~w(duration file_size encoder width height video_codec_id video_data_rate framerate audio_codec_id
                 audio_data_rate audio_sample_rate audio_sample_size stereo)a
@@ -49,6 +50,11 @@ defmodule Membrane.RTMP.Messages.SetDataFrame do
   @impl true
   def from_data(["@setDataFrame", "onMetaData", properties]) do
     new(properties)
+  end
+
+  @impl true
+  def from_data(["@setDataFrame", "onExpectAdditionalMedia", _properties] = data) do
+    OnExpectAdditionalMedia.from_data(data)
   end
 
   @spec new([{String.t(), any()}]) :: t()

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.21.0"
+  @version "0.22.0"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR introduces support for `additionalMedia` AMF data message.

It is being used in OBS by Twitch to send a second audio track that can be used for VOD purposes (replacing live audio that can be copyrighted with a non-copyrighted one).

To introduce the change `AMF3` parser is needed (we only care about the byte array type, which is why many types are not implemented).

## TODO:
- [X] transform `AdditionalMedia` message to a membrane's buffer
- [X] add callback to the message's validator to support handling modified `@setDataFrame` that indicates additional media track (it doesn't have to container `onMetaData`)
- [X] discover how we can demux the FLV stream when it contains another track (usually it can only carry one, and it is not obvious how it can be differentiated  between separate audio tracks)