### PR TITLE
Add warning message when combining body chunks with different header type

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.17.0"}
+	  {:membrane_rtmp_plugin, "~> 0.17.1"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/message_parser.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/message_parser.ex
@@ -200,6 +200,13 @@ defmodule Membrane.RTMP.MessageParser do
       <<body::binary-size(chunk_size), 0b11::2, _chunk_stream_id::6, rest::binary>> ->
         do_combine_body_chunks(rest, chunk_size, header, [acc, body])
 
+      <<_body::binary-size(chunk_size), header_type::2, _chunk_stream_id::6, _rest::binary>> ->
+        Membrane.Logger.warning(
+          "Unexpected header type when combining body chunks: #{header_type}"
+        )
+
+        IO.iodata_to_binary([acc, body])
+
       body ->
         IO.iodata_to_binary([acc, body])
     end

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.17.0"
+  @version "0.17.1"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
When it comes to RTMP specification, body chunks can have different header types than type 3. This PR is not yet a fix but a utility that will allow us to detect if such thing is happening.