### PR TITLE
Provide a fallback value for missing `flashVer`, bump package to 0.17.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.17.1"}
+	  {:membrane_rtmp_plugin, "~> 0.17.2"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
@@ -26,7 +26,6 @@ defmodule Membrane.RTMP.Messages.Connect do
     %{
       "app" => app,
       "type" => type,
-      "flashVer" => flash_version,
       "tcUrl" => tc_url
     } = properties
 
@@ -34,7 +33,8 @@ defmodule Membrane.RTMP.Messages.Connect do
       app: app,
       type: type,
       supports_go_away: Map.get(properties, "supportsGoAway", false),
-      flash_version: flash_version,
+      # some RTMP clients may not include flashVer in the message (eg. PRISM)
+      flash_version: Map.get(properties, "flashVer", "FMLE/3.0 (compatible; FMSc/1.0)"),
       swf_url: Map.get(properties, "swfUrl", tc_url),
       tc_url: tc_url,
       tx_id: tx_id

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.17.1"
+  @version "0.17.2"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
Some RTMP clients like PRISM may not include `flashVer` in `connect` message. This PR provides a fallback value for it when it's missing to prevent `MatchError`.