### PR TITLE
Make type an optional property

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.17.2"}
+	  {:membrane_rtmp_plugin, "~> 0.17.3"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/messages/command/connect.ex
@@ -25,13 +25,12 @@ defmodule Membrane.RTMP.Messages.Connect do
   def from_data([@name, tx_id, properties]) do
     %{
       "app" => app,
-      "type" => type,
       "tcUrl" => tc_url
     } = properties
 
     %__MODULE__{
       app: app,
-      type: type,
+      type: Map.get(properties, "type", ""),
       supports_go_away: Map.get(properties, "supportsGoAway", false),
       # some RTMP clients may not include flashVer in the message (eg. PRISM)
       flash_version: Map.get(properties, "flashVer", "FMLE/3.0 (compatible; FMSc/1.0)"),

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.17.2"
+  @version "0.17.3"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
It happens that some clients (e.g. nginx relay proxy) don't include the `type` property in connect command so we should probably just default to an empty string.