### PR TITLE
Fix unexpected socket closed notification

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.19.2"}
+	  {:membrane_rtmp_plugin, "~> 0.19.3"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -222,10 +222,10 @@ defmodule Membrane.RTMP.Source do
 
   @impl true
   def handle_info({:socket_closed, _socket}, ctx, state) do
-    if ctx.pads.output.end_of_stream? do
-      {[], state}
-    else
-      {[notify_parent: :unexpected_socket_closed, end_of_stream: :output], state}
+    cond do
+      ctx.pads.output.end_of_stream? -> {[], state}
+      ctx.pads.output.start_of_stream? -> {[end_of_stream: :output], state}
+      true -> {[notify_parent: :unexpected_socket_closed, end_of_stream: :output], state}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.19.2"
+  @version "0.19.3"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
The previous implementation invalidly sends the notification on every end of stream. I've already retired `0.19.2`.