### PR TITLE
Fix dirty NIF scheduler configuration for RTMP.Sink

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.22.0"}
+	  {:membrane_rtmp_plugin, "~> 0.22.1"}
   ]
 end
 ```

--- a/c_src/membrane_rtmp_plugin/sink/rtmp_sink.spec.exs
+++ b/c_src/membrane_rtmp_plugin/sink/rtmp_sink.spec.exs
@@ -27,4 +27,4 @@ spec init_audio_stream(state, channels :: int, sample_rate :: int, aac_config ::
 spec write_audio_frame(state, frame :: payload, pts :: int64) ::
        {:ok :: label, state} | {:error :: label, reason :: string}
 
-dirty :io, write_video_frame: 4, write_audio_frame: 3
+dirty :io, write_video_frame: 5, write_audio_frame: 3, try_connect: 1

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.22.0"
+  @version "0.22.1"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* Makes sure `try_connect/1` is scheduled on a dirty scheduler
* Fixes a dirty scheduler configuration for `write_video_frame/5`