### PR TITLE
Handle socket closed by client before start of stream arrives in RTMP Source Bin

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.22.1"}
+	  {:membrane_rtmp_plugin, "~> 0.23.0"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/bin.ex
@@ -105,6 +105,10 @@ defmodule Membrane.RTMP.SourceBin do
     {[notify_parent: notification], state}
   end
 
+  def handle_child_notification(:unexpected_socket_closed, :src, _ctx, state) do
+    {[notify_parent: :unexpected_socket_close], state}
+  end
+
   @doc """
   Passes the control of the socket to the `source`.
 

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.22.1"
+  @version "0.23.0"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
I had a flow in my application where the client was closing the socket before the start of stream was being sent. That was causing the RTMP source to send a message `:unexpected_socket_closed` to the parent, which in my case is the RTMP Source Bin. https://github.com/membraneframework/membrane_rtmp_plugin/blob/v0.22.1/lib/membrane_rtmp_plugin/rtmp/source/source.ex#L228

This message is not being handled by the bin so it causes a crash in my application. I have added handling for this case and decided to send the message to the bin's parent. 