### PR TITLE
Send RTMP messages to client handler

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
@@ -193,8 +193,7 @@ defmodule Membrane.RTMPServer.ClientHandler do
     state = Enum.reduce(events, state, &handle_event/2)
 
     state =
-      if state.handler &&
-           state.handler_state &&
+      if state.notified_about_client? &&
            Kernel.function_exported?(state.handler, :handle_rtmp_message, 2) do
         new_handler_state =
           Enum.reduce(messages, state.handler_state, fn


### PR DESCRIPTION
Adds optional callback `handle_rtmp_message/2` to ClientHandlerBehaviour

I've put together a demo (https://github.com/membraneframework/membrane_demo/pull/287) that uses a [custom client handler](https://github.com/lastcanal/membrane_demo/blob/20fb447764490d0db2ed86ec284d45cac8323304/rtmp_to_adaptive_hls/lib/rtmp_to_adaptive_hls/client_handler.ex#L57-L60) with the proposed `handle_rtmp_message` callback to forward RTMP messages to a pipeline that creates [multi-variant HLS playlists](https://github.com/lastcanal/membrane_demo/blob/20fb447764490d0db2ed86ec284d45cac8323304/rtmp_to_adaptive_hls/lib/rtmp_to_adaptive_hls/pipeline.ex#L42-L81).