### PR TITLE
Fix a bug with :stream_deleted message not handled in source bin.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.27.1"}
+	  {:membrane_rtmp_plugin, "~> 0.27.2"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
@@ -15,6 +15,8 @@ defmodule Membrane.RTMP.SourceBin do
 
   alias Membrane.{AAC, H264, RTMP}
 
+  require Membrane.Logger
+
   def_output_pad :video,
     accepted_format: H264,
     availability: :on_request
@@ -113,6 +115,18 @@ defmodule Membrane.RTMP.SourceBin do
 
   def handle_child_notification(:unexpected_socket_closed, :src, _ctx, state) do
     {[notify_parent: :unexpected_socket_close], state}
+  end
+
+  def handle_child_notification(:stream_deleted, :src, _ctx, state) do
+    {[notify_parent: :stream_deleted], state}
+  end
+
+  def handle_child_notification(notification, child, _ctx, state) do
+    Membrane.Logger.warning(
+      "Received unrecognized child notification from: #{inspect(child)}: #{inspect(notification)}"
+    )
+
+    {[], state}
   end
 
   @doc """

--- a/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
@@ -13,9 +13,8 @@ defmodule Membrane.RTMP.SourceBin do
   """
   use Membrane.Bin
 
-  alias Membrane.{AAC, H264, RTMP}
-
   require Membrane.Logger
+  alias Membrane.{AAC, H264, RTMP}
 
   def_output_pad :video,
     accepted_format: H264,

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.27.1"
+  @version "0.27.2"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* Fix a bug with :stream_deleted message not handled in source bin.
* Warn instead of failing if unrecogized child notification is delivered to the source bin. 
* Bump version to v0.27.2