### PR TITLE
Allow for specifying client_timeout option in Source and SourceBin. Bump to v0.28.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.27.3"}
+	  {:membrane_rtmp_plugin, "~> 0.28.0"}
   ]
 end
 ```

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -41,7 +41,7 @@ defmodule Membrane.RTMP.Source do
                 default: Membrane.Time.seconds(5),
                 spec: Membrane.Time.t(),
                 description: """
-                Time after which an unused client connection is automatically closed. Defaults to 5 seconds.
+                Time after which an unused client connection is automatically closed, expressed in `Membrane.Time.t()` units. Defaults to 5 seconds.
                 """
               ]
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/source.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source.ex
@@ -36,6 +36,13 @@ defmodule Membrane.RTMP.Source do
                 An URL on which the client is expected to connect, for example:
                 rtmp://127.0.0.1:1935/app/stream_key
                 """
+              ],
+              client_timeout: [
+                default: Membrane.Time.seconds(5),
+                spec: Membrane.Time.t(),
+                description: """
+                Time after which an unused client connection is automatically closed. Defaults to 5 seconds.
+                """
               ]
 
   defguardp is_builtin_server(opts)
@@ -54,7 +61,8 @@ defmodule Membrane.RTMP.Source do
       url: opts.url,
       mode: :builtin_server,
       client_ref: nil,
-      use_ssl?: nil
+      use_ssl?: nil,
+      client_timeout: opts.client_timeout
     }
 
     {[], state}
@@ -94,7 +102,7 @@ defmodule Membrane.RTMP.Source do
         port: port,
         use_ssl?: use_ssl?,
         handle_new_client: handle_new_client,
-        client_timeout: Membrane.Time.milliseconds(100)
+        client_timeout: state.client_timeout
       )
 
     state = %{state | app: app, stream_key: stream_key, server: server_pid}

--- a/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
@@ -44,7 +44,7 @@ defmodule Membrane.RTMP.SourceBin do
                 default: Membrane.Time.seconds(5),
                 spec: Membrane.Time.t(),
                 description: """
-                Time after which an unused client connection is automatically closed. Defaults to 5 seconds.
+                Time after which an unused client connection is automatically closed, expressed in `Membrane.Time.t()` units. Defaults to 5 seconds.
                 """
               ]
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
@@ -39,14 +39,23 @@ defmodule Membrane.RTMP.SourceBin do
                 An URL on which the client is expected to connect, for example:
                 rtmp://127.0.0.1:1935/app/stream_key
                 """
+              ],
+              client_timeout: [
+                default: Membrane.Time.seconds(5),
+                spec: Membrane.Time.t(),
+                description: """
+                Time after which an unused client connection is automatically closed. Defaults to 5 seconds.
+                """
               ]
+
 
   @impl true
   def handle_init(_ctx, %__MODULE__{} = opts) do
     spec =
       child(:src, %RTMP.Source{
         client_ref: opts.client_ref,
-        url: opts.url
+        url: opts.url,
+        client_timeout: opts.client_timeout
       })
       |> child(:demuxer, Membrane.FLV.Demuxer)
 

--- a/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/source/source_bin.ex
@@ -48,7 +48,6 @@ defmodule Membrane.RTMP.SourceBin do
                 """
               ]
 
-
   @impl true
   def handle_init(_ctx, %__MODULE__{} = opts) do
     spec =

--- a/lib/membrane_rtmp_plugin/rtmp_server.ex
+++ b/lib/membrane_rtmp_plugin/rtmp_server.ex
@@ -11,7 +11,7 @@ defmodule Membrane.RTMPServer do
       which defines how the client should behave.
   - port: Port on which RTMP server will listen. Defaults to 1935.
   - use_ssl?: If true, SSL socket (for RTMPS) will be used. Othwerwise, TCP socket (for RTMP) will be used. Defaults to false.
-  - client_timeout: Time after which an unused client connection is automatically closed. Defaults to 5 seconds.
+  - client_timeout: Time after which an unused client connection is automatically closed, expressed in `Membrane.Time.t()` units. Defaults to 5 seconds.
   - name: If not nil, value of this field will be used as a name under which the server's process will be registered. Defaults to nil.
   """
   use GenServer

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.27.3"
+  @version "0.28.0"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* adds `client_timeout` option in RTMP Source and RTMP SourceBin so that the user can specify built-in RTMPServer timeout
* sets the default `client_timeout` in these components to 5 seconds instead of 100ms as it used to happen with built-in RTMPServer
* bumps version to v0.28.0

closes https://github.com/membraneframework/membrane_core/issues/888