### PR TITLE
Handle empty client_handler

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
@@ -235,8 +235,14 @@ defmodule Membrane.RTMPServer.ClientHandler do
     # call callbacks
     case event do
       :connection_closed ->
-        new_handler_state = state.handler.handle_connection_closed(state.handler_state)
-        %{state | handler_state: new_handler_state}
+        case state.handler do
+          nil ->
+            state
+
+          _ ->
+            new_handler_state = state.handler.handle_connection_closed(state.handler_state)
+            %{state | handler_state: new_handler_state}
+        end
 
       :delete_stream ->
         new_handler_state = state.handler.handle_delete_stream(state.handler_state)

--- a/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex
@@ -239,8 +239,8 @@ defmodule Membrane.RTMPServer.ClientHandler do
           nil ->
             state
 
-          _ ->
-            new_handler_state = state.handler.handle_connection_closed(state.handler_state)
+          handler ->
+            new_handler_state = handler.handle_connection_closed(state.handler_state)
             %{state | handler_state: new_handler_state}
         end
 


### PR DESCRIPTION
We are using membrane_rtmp_plugin lib as part of our pipeline. Occasionally, once or twice a day plugin crashes with the following error:
```
UndefinedFunctionError: function nil.handle_connection_closed/1 is undefined
  ?, in nil.handle_connection_closed/1
  File "lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex", line 238, in Membrane.RTMPServer.ClientHandler.handle_event/2
  File "lib/enum.ex", line 2546, in Enum."-reduce/3-lists^foldl/2-0-"/3
  File "lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex", line 118, in Membrane.RTMPServer.ClientHandler.handle_info/2
  File "gen_server.erl", line 1095, in :gen_server.try_handle_info/3
  File "gen_server.erl", line 1183, in :gen_server.handle_msg/6
  File "proc_lib.erl", line 241, in :proc_lib.init_p_do_apply/3
```

I've been able to reproduce it locally, and this error happens even without any RTMP connections. @varsill could you take a closer look and find out if this fix makes sense?