### PR TITLE
Add `connect_in_advance` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The package can be installed by adding `membrane_rtmp_plugin` to your list of de
 ```elixir
 def deps do
   [
-	  {:membrane_rtmp_plugin, "~> 0.28.1"}
+	  {:membrane_rtmp_plugin, "~> 0.29.0"}
   ]
 end
 ```

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Membrane.RTMP.Mixfile do
   use Mix.Project
 
-  @version "0.28.1"
+  @version "0.29.0"
   @github_url "https://github.com/membraneframework/membrane_rtmp_plugin"
 
   def project do


### PR DESCRIPTION
This PR:
* Makes `reset_timestamps` disabled by default. 
* Add `connect_in_advance` option to postpone connection to RTMP server until the moment data is already available (this way we can prevent timeout in case connection is done prematurely)
* Bumps version to v0.29.0. 