### PR TITLE
Add tx_id to fix compatibility with some rtmp clients

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp/message_handler.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/message_handler.ex
@@ -171,8 +171,8 @@ defmodule Membrane.RTMP.MessageHandler do
 
   # According to ffmpeg's documentation, this command should prepare the server to receive media streams
   # We are simply acknowledging the message
-  defp do_handle_client_message(%Messages.FCPublish{}, _header, state) do
-    %Messages.Anonymous{name: "onFCPublish", properties: []}
+  defp do_handle_client_message(%Messages.FCPublish{} = fc_publish, _header, state) do
+    %Messages.Anonymous{name: "onFCPublish", tx_id: fc_publish.tx_id, properties: []}
     |> send_rtmp_payload(state.socket, chunk_stream_id: 3)
 
     {:cont, state}


### PR DESCRIPTION
We noticed issues with Livestream Studio 6 (by Vimeo) and some hardware encoders which didn't work with this RTMP library. After some debugging, it was the missing tx_id in the onFCPublish response.