### PR TITLE
Handle "@" prefix in from_data/1 events

### DIFF
--- a/lib/membrane_rtmp_plugin/rtmp/messages/additional_media.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/additional_media.ex
@@ -13,8 +13,10 @@ defmodule Membrane.RTMP.Messages.AdditionalMedia do
           media: binary()
         }
 
+  @names ["additionalMedia", "@additionalMedia"]
+
   @impl true
-  def from_data(["additionalMedia", %{"id" => id, "media" => media}]) do
+  def from_data([name, %{"id" => id, "media" => media}]) when name in @names do
     %__MODULE__{id: id, media: media}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/anonymous.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/anonymous.ex
@@ -15,6 +15,11 @@ defmodule Membrane.RTMP.Messages.Anonymous do
         }
 
   @impl true
+  def from_data(["@" <> event, properties]) do
+    from_data([event, properties])
+  end
+
+  @impl true
   def from_data([name, tx_id | properties]) when is_binary(name) do
     %__MODULE__{name: name, tx_id: tx_id, properties: properties}
   end

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/connect.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/connect.ex
@@ -52,10 +52,10 @@ defmodule Membrane.RTMP.Messages.Connect do
 
   @attributes_to_keys Map.new(@keys_to_attributes, fn {key, attribute} -> {attribute, key} end)
 
-  @name "connect"
+  @names ["connect", "@connect"]
 
   @impl true
-  def from_data([@name, tx_id, properties]) do
+  def from_data([name, tx_id, properties]) when name in @names do
     # We take keys according to RFC, but preserve all extra ones
     # https://github.com/melpon/rfc/blob/master/rtmp.md#7211-connect
     {rfc, extra} = Map.split(properties, Map.keys(@attributes_to_keys))

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/create_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/create_stream.ex
@@ -11,10 +11,10 @@ defmodule Membrane.RTMP.Messages.CreateStream do
           tx_id: non_neg_integer()
         }
 
-  @name "createStream"
+  @names ["createStream", "@createStream"]
 
   @impl true
-  def from_data([@name, tx_id, :null]) do
+  def from_data([name, tx_id, :null]) when name in @names do
     %__MODULE__{tx_id: tx_id}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/delete_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/delete_stream.ex
@@ -14,10 +14,10 @@ defmodule Membrane.RTMP.Messages.DeleteStream do
           stream_id: non_neg_integer()
         }
 
-  @name "deleteStream"
+  @names ["deleteStream", "@deleteStream"]
 
   @impl true
-  def from_data([@name, tx_id, :null, stream_id]) do
+  def from_data([name, tx_id, :null, stream_id]) when name in @names do
     %__MODULE__{tx_id: tx_id, stream_id: stream_id}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/fc_publish.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/fc_publish.ex
@@ -13,10 +13,10 @@ defmodule Membrane.RTMP.Messages.FCPublish do
           tx_id: non_neg_integer()
         }
 
-  @name "FCPublish"
+  @names ["FCPublish", "@FCPublish"]
 
   @impl true
-  def from_data([@name, tx_id, :null, stream_key]) do
+  def from_data([name, tx_id, :null, stream_key]) when name in @names do
     %__MODULE__{tx_id: tx_id, stream_key: stream_key}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/publish.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/publish.ex
@@ -17,14 +17,14 @@ defmodule Membrane.RTMP.Messages.Publish do
           tx_id: non_neg_integer()
         }
 
-  @name "publish"
+  @names ["publish", "@publish"]
 
   @impl true
-  def from_data([@name, tx_id, :null, stream_key, publish_type]) do
+  def from_data([name, tx_id, :null, stream_key, publish_type]) when name in @names do
     %__MODULE__{tx_id: tx_id, stream_key: stream_key, publish_type: publish_type}
   end
 
-  def from_data([@name, tx_id, :null, stream_key]) do
+  def from_data([name, tx_id, :null, stream_key]) when name in @names do
     %__MODULE__{tx_id: tx_id, stream_key: stream_key}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/command/release_stream.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/command/release_stream.ex
@@ -15,10 +15,10 @@ defmodule Membrane.RTMP.Messages.ReleaseStream do
           tx_id: non_neg_integer()
         }
 
-  @name "releaseStream"
+  @names ["releaseStream", "@releaseStream"]
 
   @impl true
-  def from_data([@name, tx_id, :null, stream_key]) do
+  def from_data([name, tx_id, :null, stream_key]) when name in @names do
     %__MODULE__{tx_id: tx_id, stream_key: stream_key}
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/on_expect_additional_media.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/on_expect_additional_media.ex
@@ -27,8 +27,10 @@ defmodule Membrane.RTMP.Messages.OnExpectAdditionalMedia do
           processing_intents: [String.t()]
         }
 
+  @names ["onExpectAdditionalMedia", "@onExpectAdditionalMedia"]
+
   @impl true
-  def from_data(["@setDataFrame", "onExpectAdditionalMedia", properties]) do
+  def from_data(["@setDataFrame", name, properties]) when name in @names do
     new(properties)
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/on_meta_data.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/on_meta_data.ex
@@ -35,8 +35,10 @@ defmodule Membrane.RTMP.Messages.OnMetaData do
           audio_data_rate: number()
         }
 
+  @names ["onMetaData", "@onMetaData"]
+
   @impl true
-  def from_data(["onMetaData", properties]) do
+  def from_data([name, properties]) when name in @names do
     new(properties)
   end
 

--- a/lib/membrane_rtmp_plugin/rtmp/messages/set_data_frame.ex
+++ b/lib/membrane_rtmp_plugin/rtmp/messages/set_data_frame.ex
@@ -57,6 +57,11 @@ defmodule Membrane.RTMP.Messages.SetDataFrame do
     OnExpectAdditionalMedia.from_data(data)
   end
 
+  @impl true
+  def from_data(["@setDataFrame", "@" <> event, properties]) do
+    from_data(["@setDataFrame", event, properties])
+  end
+
   @spec new([{String.t(), any()}]) :: t()
   def new(options) do
     params =

--- a/test/membrane_rtmp_plugin/rtmp_messages_test.exs
+++ b/test/membrane_rtmp_plugin/rtmp_messages_test.exs
@@ -1,0 +1,105 @@
+defmodule Membrane.RTMP.MessagesTest do
+  use ExUnit.Case, async: true
+
+  alias Membrane.RTMP.Messages.AdditionalMedia
+  alias Membrane.RTMP.Messages.Anonymous
+  alias Membrane.RTMP.Messages.Connect
+  alias Membrane.RTMP.Messages.CreateStream
+  alias Membrane.RTMP.Messages.DeleteStream
+  alias Membrane.RTMP.Messages.FCPublish
+  alias Membrane.RTMP.Messages.OnExpectAdditionalMedia
+  alias Membrane.RTMP.Messages.OnMetaData
+  alias Membrane.RTMP.Messages.Publish
+  alias Membrane.RTMP.Messages.ReleaseStream
+  alias Membrane.RTMP.Messages.SetDataFrame
+
+  test "Connect accepts @connect alias" do
+    props = %{"app" => "live", "tcUrl" => "rtmp://localhost/live", "custom" => "value"}
+
+    assert Connect.from_data(["@connect", 1, props]) == Connect.from_data(["connect", 1, props])
+  end
+
+  test "CreateStream accepts @createStream alias" do
+    assert CreateStream.from_data(["@createStream", 2, :null]) ==
+             CreateStream.from_data(["createStream", 2, :null])
+  end
+
+  test "DeleteStream accepts @deleteStream alias" do
+    assert DeleteStream.from_data(["@deleteStream", 3, :null, 10]) ==
+             DeleteStream.from_data(["deleteStream", 3, :null, 10])
+  end
+
+  test "FCPublish accepts @FCPublish alias" do
+    assert FCPublish.from_data(["@FCPublish", 4, :null, "stream_key"]) ==
+             FCPublish.from_data(["FCPublish", 4, :null, "stream_key"])
+  end
+
+  test "Publish accepts @publish alias with publish type" do
+    assert Publish.from_data(["@publish", 5, :null, "stream_key", "live"]) ==
+             Publish.from_data(["publish", 5, :null, "stream_key", "live"])
+  end
+
+  test "Publish accepts @publish alias without publish type" do
+    assert Publish.from_data(["@publish", 6, :null, "stream_key"]) ==
+             Publish.from_data(["publish", 6, :null, "stream_key"])
+  end
+
+  test "ReleaseStream accepts @releaseStream alias" do
+    assert ReleaseStream.from_data(["@releaseStream", 7, :null, "stream_key"]) ==
+             ReleaseStream.from_data(["releaseStream", 7, :null, "stream_key"])
+  end
+
+  test "AdditionalMedia accepts @additionalMedia alias" do
+    props = %{"id" => "track-1", "media" => <<1, 2, 3>>}
+
+    assert AdditionalMedia.from_data(["@additionalMedia", props]) ==
+             AdditionalMedia.from_data(["additionalMedia", props])
+  end
+
+  test "Anonymous strips @ prefix" do
+    props = %{"level" => "status"}
+
+    assert Anonymous.from_data(["@onStatus", props]) ==
+             Anonymous.from_data(["onStatus", props])
+  end
+
+  test "OnMetaData accepts @onMetaData alias" do
+    props = %{"duration" => 12.0, "width" => 1920.0}
+
+    assert OnMetaData.from_data(["@onMetaData", props]) ==
+             OnMetaData.from_data(["onMetaData", props])
+  end
+
+  test "SetDataFrame accepts nested @onMetaData alias" do
+    props = %{"duration" => 12.0, "width" => 1920.0}
+
+    assert SetDataFrame.from_data(["@setDataFrame", "@onMetaData", props]) ==
+             SetDataFrame.from_data(["@setDataFrame", "onMetaData", props])
+  end
+
+  test "SetDataFrame accepts nested @onExpectAdditionalMedia alias" do
+    props = %{
+      "additionalMedia" => %{"id" => "track-1"},
+      "defaultMedia" => %{"id" => "track-0"},
+      "processingIntents" => ["transcode"]
+    }
+
+    assert SetDataFrame.from_data(["@setDataFrame", "@onExpectAdditionalMedia", props]) ==
+             SetDataFrame.from_data(["@setDataFrame", "onExpectAdditionalMedia", props])
+  end
+
+  test "OnExpectAdditionalMedia accepts nested @onExpectAdditionalMedia alias" do
+    props = %{
+      "additionalMedia" => %{"id" => "track-1"},
+      "defaultMedia" => %{"id" => "track-0"},
+      "processingIntents" => ["transcode"]
+    }
+
+    assert OnExpectAdditionalMedia.from_data(["@setDataFrame", "@onExpectAdditionalMedia", props]) ==
+             OnExpectAdditionalMedia.from_data([
+               "@setDataFrame",
+               "onExpectAdditionalMedia",
+               props
+             ])
+  end
+end


### PR DESCRIPTION
When using RTMP plugin with streams from some ip camera vendor, we got errors:
```
lib/membrane_rtmp_plugin/rtmp/messages/set_data_frame.ex in Membrane.RTMP.Messages.SetDataFrame.from_data/1 at line 51

lib/membrane_rtmp_plugin/rtmp/message_parser.ex in Membrane.RTMP.MessageParser.read_frame/3 at line 188
lib/membrane_rtmp_plugin/rtmp/message_parser.ex in Membrane.RTMP.MessageParser.handle_packet/2 at line 107
lib/membrane_rtmp_plugin/rtmp/message_parser.ex in Membrane.RTMP.MessageParser.parse_packet_messages/3 at line 68
lib/membrane_rtmp_plugin/rtmp_server/client_handler.ex in Membrane.RTMPServer.ClientHandler.handle_data/2 at line 168
gen_server.erl in :gen_server.try_handle_info/3 at line 2434
gen_server.erl in :gen_server.handle_msg/3 at line 2420
proc_lib.erl in :proc_lib.init_p_do_apply/3 at line 333
```
with following arguments: `["@setDataFrame", "@onMetaData", %{"framerate" => 25.0, "height" => 1080.0, "width" => 1920.0}]`
Assuming that some vendors, doesn't follow RTMP spec, current PR should resolve the issue.